### PR TITLE
WIP [#130899727] Backport grok parsing patterns for gorouter logs

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
@@ -9,7 +9,14 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
     }
 
     grok {
-      match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[rtr][vcap_request_id]} response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}" ]
+      match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}" ]
+
+      # cf-release v250+
+      match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"(%{HOSTPORT}|-)\" \"(%{HOSTPORT}|-)\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}" ]
+
+      # cf-release v252+
+      match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}T%{TIME}+%{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]:int}\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]:int}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"%{BASE10NUM:[rtr][app][index]:int}\""]
+
       tag_on_failure => [ "fail/cloudfoundry/app-rtr/grok" ]
     }
 
@@ -38,7 +45,11 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
 
         # Set [rtr][response_time_ms]
         ruby {
-           code => "event['rtr']['response_time_ms'] = (event['rtr']['response_time_sec']*1000).to_int"
+           code => '
+             rtr = event.get("rtr")
+             rtr["response_time_ms"] = (rtr["response_time_sec"]*1000).to_int
+             event.set("rtr", rtr)
+           '
            remove_field => "[rtr][response_time_sec]"
         }
 


### PR DESCRIPTION
## What

We currently have a fork of the upstream repo in order to include a
fix[1]. This fix has now been merged, however, it is only available in
the latest release (v206.0.0) and this in turn requires the latest
version of logsearch which requires a major version upgrade of ES and
Kibana.

We have elected to backport the changes we require in order to avoid
having to do the ES/Kibana upgrade.

[1] https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/255

## How 

Sanity check.

## Who

Not @chrisfarms. Not @samcrang