### PR TITLE
[#134014357] Handle RFC 5424 syslog format for CF platform logs

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/platform.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform.conf
@@ -4,27 +4,45 @@
 if [@index_type] == "platform" {
 
     mutate {
-      replace => { "[@source][type]" => "system" } # default for platform logs
-      add_tag => "platform"
+        replace => { "[@source][type]" => "system" } # default for platform logs
+        add_tag => "platform"
     }
 
-    # Try parsing with possible CF formats
-    grok {
-      # Metron agent format (https://github.com/cloudfoundry/loggregator/blob/master/jobs/metron_agent/templates/syslog_forwarder.conf.erb#L53)
-      match => [ "@message", "\[job=%{NOTSPACE:[@source][job]} index=%{NOTSPACE:[@source][instance]}\]%{SPACE}%{GREEDYDATA:@message}" ]
-
-      # Syslog release format (https://github.com/cloudfoundry/syslog-release/blob/master/jobs/syslog_forwarder/templates/rsyslog.conf.erb#L56)
-      match => [ "@message", "\[bosh instance=%{NOTSPACE:[@source][deployment]}/%{NOTSPACE:[@source][job]}/%{NOTSPACE}\]%{SPACE}%{GREEDYDATA:@message}" ]
-
-      overwrite => [ "@message" ] # @message
-      tag_on_failure => "fail/cloudfoundry/platform/grok"
-    }
-
-    if !("fail/cloudfoundry/platform/grok" in [tags]) {
+    # Syslog message with RFC 5424 and the enterprise number is CF
+    if [syslog_sd_id] == "instance@47450" {
         mutate {
-          replace => { "[@source][type]" => "cf" }
-          replace => { "@type" => "cf" }
-          add_tag => "cf"
+            add_field => {
+                "[@source][az]" => "%{[syslog_sd_params][az]}"
+                "[@source][deployment]" => "%{[syslog_sd_params][deployment]}"
+                "[@source][director]" => "%{[syslog_sd_params][director]}"
+                "[@source][id]" => "%{[syslog_sd_params][id]}"
+                "[@source][job]" => "%{[syslog_sd_params][group]}"
+            }
+            replace => {
+                "[@source][type]" => "cf"
+                "@type" => "cf"
+            }
+            add_tag => "cf"
+        }
+    } else {
+        # Try parsing with possible CF formats
+        grok {
+            # Metron agent format (https://github.com/cloudfoundry/loggregator/blob/master/jobs/metron_agent/templates/syslog_forwarder.conf.erb#L53)
+            match => [ "@message", "\[job=%{NOTSPACE:[@source][job]} index=%{NOTSPACE:[@source][instance]}\]%{SPACE}%{GREEDYDATA:@message}" ]
+
+            # Syslog release format (https://github.com/cloudfoundry/syslog-release/blob/master/jobs/syslog_forwarder/templates/rsyslog.conf.erb#L56)
+            match => [ "@message", "\[bosh instance=%{NOTSPACE:[@source][deployment]}/%{NOTSPACE:[@source][job]}/%{NOTSPACE}\]%{SPACE}%{GREEDYDATA:@message}" ]
+
+            overwrite => [ "@message" ] # @message
+            tag_on_failure => "fail/cloudfoundry/platform/grok"
+        }
+
+        if !("fail/cloudfoundry/platform/grok" in [tags]) {
+            mutate {
+                replace => { "[@source][type]" => "cf" }
+                replace => { "@type" => "cf" }
+                add_tag => "cf"
+            }
         }
     }
 }

--- a/src/logsearch-config/test/logstash-filters/snippets/platform-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/platform-spec.rb
@@ -86,6 +86,36 @@ describe "platform.conf" do
       end
     end
 
+    context "RFC 5424 format and enterprise number is CF" do
+      when_parsing_log(
+          "@index_type" => "platform",
+          "@message" => "Some message",
+          "syslog_sd_id" => "instance@47450",
+          "syslog_sd_params" => {
+            "az" => "az1",
+            "deployment" => "deployment1",
+            "director" => "director1",
+            "group" => "group1",
+            "id" => "id1",
+          },
+      ) do
+
+        it { expect(subject["tags"]).to eq ["platform", "cf"] } # no fail tag
+
+        it { expect(subject["@source"]["type"]).to eq "cf" }
+        it { expect(subject["@type"]).to eq "cf" }
+
+        it "sets the common fields" do
+          expect(subject["@message"]).to eq "Some message"
+          expect(subject["@source"]["az"]).to eq "az1"
+          expect(subject["@source"]["deployment"]).to eq "deployment1"
+          expect(subject["@source"]["director"]).to eq "director1"
+          expect(subject["@source"]["id"]).to eq "id1"
+          expect(subject["@source"]["job"]).to eq "group1"
+        end
+      end
+    end
+
     context "not CF format" do
       when_parsing_log(
           "@index_type" => "platform",


### PR DESCRIPTION
# What

The latest syslog-release project introduced a new Syslog log format which is
based on RFC 5424 [1]. This format is automatically parsed by the Logstash
filters defined in [2] therefore the grok filters will fail in platform.conf.

We check for syslog_sd_id first and make sure the common fields and tags are set.

[1] https://github.com/cloudfoundry/syslog-release/blob/e58e88281429f0bac1313994db447fce22b29106/jobs/syslog_forwarder/templates/rsyslog.conf.erb#L54
[2] https://github.com/cloudfoundry-community/logsearch-boshrelease/blob/9c0376bfd403cc63df058a30e6e27e4f0b41c889/src/logsearch-config/src/logstash-filters/snippets/syslog_standard.conf#L3

We also opened an upstream PR: https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/291.

# How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1185.

# Who can review it

Not @LeePorte or @bandesz