### PR TITLE
[#156302820] Enable blackbox

### DIFF
--- a/src/logsearch-config/spec/logstash-filters/integration/platform_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/integration/platform_spec.rb
@@ -29,11 +29,11 @@ describe "Platform IT" do
           .build()
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__metronagent_format(message_payload)
-      sample_event["syslog_program"] = "vcap.consul-agent" # vcap
+      sample_event["syslog_program"] = "consul-agent" # vcap
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__metronagent_format("vcap.consul-agent_relp", "consul-agent", "nfs_z1",
+        verify_platform_cf_fields__metronagent_format("consul-agent_relp", "consul-agent", "nfs_z1",
           "vcap", ["platform", "cf", "vcap"], "Some vcap plain text message", "ERROR")
 
         it { expect(parsed_results.get("consul_agent")).to be_nil } # no json fields
@@ -52,11 +52,11 @@ describe "Platform IT" do
                             .build() # JSON message
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__metronagent_format(message_payload)
-      sample_event["syslog_program"] = "vcap.consul-agent" # vcap
+      sample_event["syslog_program"] = "consul-agent" # vcap
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__metronagent_format("vcap.consul-agent_relp", "consul-agent", "nfs_z1",
+        verify_platform_cf_fields__metronagent_format("consul-agent_relp", "consul-agent", "nfs_z1",
                       "vcap", ["platform", "cf", "vcap"], "router.register", "INFO")
 
         # json fields
@@ -126,11 +126,11 @@ describe "Platform IT" do
                             .build()
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__metronagent_format(message_payload)
-      sample_event["syslog_program"] = "vcap.uaa" # uaa
+      sample_event["syslog_program"] = "uaa" # uaa
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__metronagent_format("vcap.uaa_relp", "uaa", "uaa_z0",
+        verify_platform_cf_fields__metronagent_format("uaa_relp", "uaa", "uaa_z0",
                       "uaa", ["platform", "cf", "uaa"],
                       "/healthz has an empty filter list", "DEBUG")
 
@@ -151,11 +151,11 @@ describe "Platform IT" do
                             .build()
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__metronagent_format(message_payload)
-      sample_event["syslog_program"] = "vcap.uaa" # uaa
+      sample_event["syslog_program"] = "uaa" # uaa
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__metronagent_format("vcap.uaa_relp", "uaa", "uaa_z0",
+        verify_platform_cf_fields__metronagent_format("uaa_relp", "uaa", "uaa_z0",
                                   "uaa-audit", ["platform", "cf", "uaa", "audit"],
                                   "ClientAuthenticationSuccess ('Client authentication success')", "INFO")
 
@@ -196,11 +196,11 @@ describe "Platform IT" do
                             .build()
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__syslogrelease_format(message_payload)
-      sample_event["syslog_program"] = "vcap.consul-agent" # vcap
+      sample_event["syslog_program"] = "consul-agent" # vcap
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__syslogrelease_format("vcap.consul-agent_relp", "cf_full", "consul-agent", "nfs_z1",
+        verify_platform_cf_fields__syslogrelease_format("consul-agent_relp", "cf_full", "consul-agent", "nfs_z1",
                                   "vcap", ["platform", "cf", "vcap"], "Some vcap plain text message", "ERROR")
 
         it { expect(parsed_results.get("consul_agent")).to be_nil } # no json fields
@@ -220,11 +220,11 @@ describe "Platform IT" do
                             .build() # JSON message
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__syslogrelease_format(message_payload)
-      sample_event["syslog_program"] = "vcap.consul-agent" # vcap
+      sample_event["syslog_program"] = "consul-agent" # vcap
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__syslogrelease_format("vcap.consul-agent_relp", "cf_full", "consul-agent", "nfs_z1",
+        verify_platform_cf_fields__syslogrelease_format("consul-agent_relp", "cf_full", "consul-agent", "nfs_z1",
                                   "vcap", ["platform", "cf", "vcap"], "router.register", "INFO")
 
         # json fields
@@ -296,11 +296,11 @@ describe "Platform IT" do
                             .build()
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__syslogrelease_format(message_payload)
-      sample_event["syslog_program"] = "vcap.uaa" # uaa
+      sample_event["syslog_program"] = "uaa" # uaa
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__syslogrelease_format("vcap.uaa_relp", "cf_full", "uaa", "uaa_z0",
+        verify_platform_cf_fields__syslogrelease_format("uaa_relp", "cf_full", "uaa", "uaa_z0",
                                   "uaa", ["platform", "cf", "uaa"],
                                   "/healthz has an empty filter list", "DEBUG")
 
@@ -322,11 +322,11 @@ describe "Platform IT" do
                             .build()
       sample_event = platform_event_dummy.clone
       sample_event["@message"] = construct_cf_message__syslogrelease_format(message_payload)
-      sample_event["syslog_program"] = "vcap.uaa" # uaa
+      sample_event["syslog_program"] = "uaa" # uaa
 
       when_parsing_log(sample_event) do
 
-        verify_platform_cf_fields__syslogrelease_format("vcap.uaa_relp", "cf_full", "uaa", "uaa_z0",
+        verify_platform_cf_fields__syslogrelease_format("uaa_relp", "cf_full", "uaa", "uaa_z0",
                                   "uaa-audit", ["platform", "cf", "uaa", "audit"],
                                   "ClientAuthenticationSuccess ('Client authentication success')", "INFO")
 
@@ -372,4 +372,3 @@ describe "Platform IT" do
   end
 
 end
-

--- a/src/logsearch-config/spec/logstash-filters/integration/platform_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/integration/platform_spec.rb
@@ -34,7 +34,7 @@ describe "Platform IT" do
       when_parsing_log(sample_event) do
 
         verify_platform_cf_fields__metronagent_format("consul-agent_relp", "consul-agent", "nfs_z1",
-          "vcap", ["platform", "cf", "vcap"], "Some vcap plain text message", "ERROR")
+          "cf", ["platform", "cf"], "Some vcap plain text message", "ERROR")
 
         it { expect(parsed_results.get("consul_agent")).to be_nil } # no json fields
 
@@ -57,7 +57,7 @@ describe "Platform IT" do
       when_parsing_log(sample_event) do
 
         verify_platform_cf_fields__metronagent_format("consul-agent_relp", "consul-agent", "nfs_z1",
-                      "vcap", ["platform", "cf", "vcap"], "router.register", "INFO")
+                      "cf", ["platform", "cf"], "router.register", "INFO")
 
         # json fields
         it "sets fields from JSON" do
@@ -201,7 +201,7 @@ describe "Platform IT" do
       when_parsing_log(sample_event) do
 
         verify_platform_cf_fields__syslogrelease_format("consul-agent_relp", "cf_full", "consul-agent", "nfs_z1",
-                                  "vcap", ["platform", "cf", "vcap"], "Some vcap plain text message", "ERROR")
+                                  "cf", ["platform", "cf"], "Some vcap plain text message", "ERROR")
 
         it { expect(parsed_results.get("consul_agent")).to be_nil } # no json fields
 
@@ -225,7 +225,7 @@ describe "Platform IT" do
       when_parsing_log(sample_event) do
 
         verify_platform_cf_fields__syslogrelease_format("consul-agent_relp", "cf_full", "consul-agent", "nfs_z1",
-                                  "vcap", ["platform", "cf", "vcap"], "router.register", "INFO")
+                                  "cf", ["platform", "cf"], "router.register", "INFO")
 
         # json fields
         it "sets fields from JSON" do

--- a/src/logsearch-config/spec/logstash-filters/snippets/platform_uaa_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/platform_uaa_spec.rb
@@ -15,28 +15,12 @@ describe "platform-uaa.conf" do
 
     describe "passed" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.uaa"}, # good value
+          "@source" => {"component" => "uaa"}, # good value
           "@message" => "Some message"
       ) do
 
         # tag set => 'if' succeeded
         it { expect(parsed_results.get("tags")).to include "uaa" }
-
-      end
-    end
-
-    describe "failed" do
-      when_parsing_log(
-          "@source" => {"component" => "some value"}, # bad value
-          "@message" => "Some message"
-      ) do
-
-        # no tags set => 'if' failed
-        it { expect(parsed_results.get("tags")).to be_nil }
-
-        it { expect(parsed_results.get("@type")).to be_nil } # keeps unchanged
-        it { expect(parsed_results.get("@source")["component"]).to eq "some value" } # keeps unchanged
-        it { expect(parsed_results.get("@message")).to eq "Some message" } # keeps unchanged
 
       end
     end
@@ -49,7 +33,7 @@ describe "platform-uaa.conf" do
     context "UAA" do
       context "(general event)" do
         when_parsing_log(
-            "@source" => {"component" => "vcap.uaa"},
+            "@source" => {"component" => "uaa"},
             # general UAA event
             "@message" => "[2016-07-05 04:02:18.245] uaa - 15178 [http-bio-8080-exec-14] ....  DEBUG --- FilterChainProxy: /healthz has an empty filter list"
         ) do
@@ -73,7 +57,7 @@ describe "platform-uaa.conf" do
 
       context "(bad format)" do
         when_parsing_log(
-            "@source" => {"component" => "vcap.uaa"},
+            "@source" => {"component" => "uaa"},
             "@message" => "Some message" # bad format
         ) do
 
@@ -93,7 +77,7 @@ describe "platform-uaa.conf" do
     context "UAA Audit" do
       context "(general event)" do
         when_parsing_log(
-          "@source" => {"component" => "vcap.uaa"},
+          "@source" => {"component" => "uaa"},
           # general UAA event
           "@message" => "[2016-07-05 04:02:18.245] uaa - 15178 [http-bio-8080-exec-14] ....  INFO --- Audit: ClientAuthenticationSuccess ('Client authentication success'): principal=cf, origin=[remoteAddress=64.78.155.208, clientId=cf], identityZoneId=[uaa]"
         ) do
@@ -131,7 +115,7 @@ describe "platform-uaa.conf" do
 
       context "(PrincipalAuthFailure event)" do
         when_parsing_log(
-            "@source" => {"component" => "vcap.uaa"},
+            "@source" => {"component" => "uaa"},
             # PrincipalAuthFailure event
             "@message" => "[2016-07-06 09:18:43.397] uaa - 15178 [http-bio-8080-exec-6] ....  INFO --- Audit: " +
                 "PrincipalAuthenticationFailure ('null'): principal=admin, origin=[82.209.244.50], identityZoneId=[uaa]"
@@ -170,7 +154,7 @@ describe "platform-uaa.conf" do
 
       context "(bad format)" do
         when_parsing_log(
-            "@source" => {"component" => "vcap.uaa"},
+            "@source" => {"component" => "uaa"},
             "@message" => "[2016-07-06 09:18:43.397] uaa - 15178 [http-bio-8080-exec-6] ....  INFO --- Audit: Some message" # bad format
         ) do
 

--- a/src/logsearch-config/spec/logstash-filters/snippets/platform_vcap_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/platform_vcap_spec.rb
@@ -40,6 +40,21 @@ describe "platform-vcap.conf" do
       end
     end
 
+    describe "audispd logs" do
+      when_parsing_log(
+          "@source" => {"component" => "audispd"},
+          "@message" => "Some message"
+      ) do
+
+        # no tags set => 'if' failed
+        it { expect(parsed_results.get("tags")).to be_nil }
+
+        it { expect(parsed_results.get("@type")).to be_nil } # keeps unchanged
+        it { expect(parsed_results.get("@message")).to eq "Some message" } # keeps unchanged
+
+      end
+    end
+
   end
 
   # -- general case

--- a/src/logsearch-config/spec/logstash-filters/snippets/platform_vcap_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/platform_vcap_spec.rb
@@ -15,7 +15,7 @@ describe "platform-vcap.conf" do
 
     describe "passed" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.some_component"}, # good value
+          "@source" => {"component" => "some_component"}, # good value
           "@message" => "Some message"
       ) do
 
@@ -25,17 +25,16 @@ describe "platform-vcap.conf" do
       end
     end
 
-    describe "failed" do
+    describe "uaa logs" do
       when_parsing_log(
-          "@source" => {"component" => "some value"}, # bad value
+          "@source" => {"component" => "uaa"},
           "@message" => "Some message"
       ) do
 
         # no tags set => 'if' failed
         it { expect(parsed_results.get("tags")).to be_nil }
 
-        it { expect(parsed_results.get("@type")).to be_nil } # keeps the same
-        it { expect(parsed_results.get("@source")["component"]).to eq "some value" } # keeps unchanged
+        it { expect(parsed_results.get("@type")).to be_nil } # keeps unchanged
         it { expect(parsed_results.get("@message")).to eq "Some message" } # keeps unchanged
 
       end
@@ -48,7 +47,7 @@ describe "platform-vcap.conf" do
 
     context "plain-text format" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.consul-agent"},
+          "@source" => {"component" => "consul-agent"},
           "@level" => "Dummy level",
           # plain-text format
           "@message" => "2016/07/07 00:56:10 [WARN] agent: Check 'service:routing-api' is now critical"
@@ -72,7 +71,7 @@ describe "platform-vcap.conf" do
 
     context "JSON format" do
       when_parsing_log(
-          "@source"=> { "component" => "vcap.nats" },
+          "@source"=> { "component" => "nats" },
           # JSON format
           "@message" => "{\"timestamp\":1467852972.554088,\"source\":\"NatsStreamForwarder\",\"log_level\":\"info\",\"message\":\"router.register\",\"data\":{\"nats_message\": \"{\\\"uris\\\":[\\\"redis-broker.64.78.234.207.xip.io\\\"],\\\"host\\\":\\\"192.168.111.201\\\",\\\"port\\\":80}\",\"reply_inbox\":\"_INBOX.7e93f2a1d5115844163cc930b5\"}}"
       ) do
@@ -108,7 +107,7 @@ describe "platform-vcap.conf" do
 
     context "JSON format (invalid)" do
       when_parsing_log(
-          "@source" => { "component" => "vcap.nats" },
+          "@source" => { "component" => "nats" },
           "@level" => "Dummy value",
           # JSON format
           "@message" => "{\"timestamp\":14678, abcd}}" # invalid JSON
@@ -134,7 +133,7 @@ describe "platform-vcap.conf" do
 
     context "(DEBUG)" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.dummy"},
+          "@source" => {"component" => "dummy"},
           "@message" => "{\"log_level\":0}"
       ) do
 
@@ -145,7 +144,7 @@ describe "platform-vcap.conf" do
 
     context "(INFO)" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.dummy"},
+          "@source" => {"component" => "dummy"},
           "@message" => "{\"log_level\":1}"
       ) do
 
@@ -156,7 +155,7 @@ describe "platform-vcap.conf" do
 
     context "(ERROR)" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.dummy"},
+          "@source" => {"component" => "dummy"},
           "@message" => "{\"log_level\":2}"
       ) do
 
@@ -167,7 +166,7 @@ describe "platform-vcap.conf" do
 
     context "(FATAL)" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.dummy"},
+          "@source" => {"component" => "dummy"},
           "@message" => "{\"log_level\":3}"
       ) do
 
@@ -178,7 +177,7 @@ describe "platform-vcap.conf" do
 
     context "(fallback)" do
       when_parsing_log(
-          "@source" => {"component" => "vcap.dummy"},
+          "@source" => {"component" => "dummy"},
           "@message" => "{\"log_level\":8}" # unknown log level
       ) do
 

--- a/src/logsearch-config/spec/logstash-filters/snippets/platform_vcap_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/platform_vcap_spec.rb
@@ -13,18 +13,6 @@ describe "platform-vcap.conf" do
 
   describe "#if" do
 
-    describe "passed" do
-      when_parsing_log(
-          "@source" => {"component" => "some_component"}, # good value
-          "@message" => "Some message"
-      ) do
-
-        # tag set => 'if' succeeded
-        it { expect(parsed_results.get("tags")).to include "vcap" }
-
-      end
-    end
-
     describe "uaa logs" do
       when_parsing_log(
           "@source" => {"component" => "uaa"},
@@ -68,10 +56,6 @@ describe "platform-vcap.conf" do
           "@message" => "2016/07/07 00:56:10 [WARN] agent: Check 'service:routing-api' is now critical"
       ) do
 
-        it { expect(parsed_results.get("tags")).to eq ["vcap"] } # vcap tag, no fail tag
-
-        it { expect(parsed_results.get("@type")).to eq "vcap" }
-
         it { expect(parsed_results.get("@source")["component"]).to eq "consul-agent" }
 
         it { expect(parsed_results.get("@message"))
@@ -92,10 +76,6 @@ describe "platform-vcap.conf" do
       ) do
 
         # no parsing errors
-        it { expect(parsed_results.get("tags")).to eq ["vcap"] } # vcap tag, no fail tag
-
-        it { expect(parsed_results.get("@type")).to eq "vcap" }
-
         it { expect(parsed_results.get("@source")["component"]).to eq "nats" }
 
         it "sets JSON fields" do
@@ -129,9 +109,8 @@ describe "platform-vcap.conf" do
       ) do
 
         # parsing error
-        it { expect(parsed_results.get("tags")).to eq ["vcap", "fail/cloudfoundry/platform-vcap/json"] }
+        it { expect(parsed_results.get("tags")).to eq ["fail/cloudfoundry/platform-vcap/json"] }
 
-        it { expect(parsed_results.get("@type")).to eq "vcap" }
         it { expect(parsed_results.get("@message")).to eq "{\"timestamp\":14678, abcd}}" } # keeps unchanged
         it { expect(parsed_results.get("@source")["component"]).to eq "nats" } # keeps unchanged
         it { expect(parsed_results.get("@level")).to eq "Dummy value" } # keeps unchanged

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-uaa.conf
@@ -1,12 +1,11 @@
 ##--------------------------
 # Uaa conf. Parses uaa logs.|
 ##--------------------------
-if [@source][component] == "vcap.uaa" {
+if [@source][component] == "uaa" {
 
     # ---- Parse UAA events (general)
 
     mutate {
-      replace => { "[@source][component]" => "uaa" } # remove vcap. prefix
       replace => { "@type" => "uaa" }
       add_tag => "uaa"
     }
@@ -65,4 +64,3 @@ if [@source][component] == "vcap.uaa" {
 
     }
 }
-

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
@@ -1,7 +1,7 @@
 ##-----------------------------
 # Vcap conf. Parses vcap* logs.|
 ##-----------------------------
-if [@source][component] != "uaa" {
+if [@source][component] != "uaa" and [@source][component] != "audispd" {
 
     mutate {
       replace => { "@type" => "vcap" }

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
@@ -1,14 +1,8 @@
 ##-----------------------------
 # Vcap conf. Parses vcap* logs.|
 ##-----------------------------
-if [@source][component] != "vcap.uaa" and [@source][component] =~ /vcap\..*/ {
+if [@source][component] != "uaa" {
 
-    ruby {
-      code => '
-        component_name = event.get("[@source][component]")[5..-1]
-        event.set("[@source][component]", component_name)
-      ' # minus vcap. prefix
-    }
     mutate {
       replace => { "@type" => "vcap" }
       add_tag => "vcap"

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
@@ -3,11 +3,6 @@
 ##-----------------------------
 if [@source][component] != "uaa" and [@source][component] != "audispd" {
 
-    mutate {
-      replace => { "@type" => "vcap" }
-      add_tag => "vcap"
-    }
-
     # Parse Cloud Foundry logs
     if [@message] =~ /^\s*{".*}\s*$/ { # looks like JSON
 


### PR DESCRIPTION
## What

Remove vcap. prefix handling from the Logstash filters

We enabled blackbox which removes the vcap. prefix from the syslog program name (which becomes @source.component).

As we can't differentiate between vcap and non-vcap logs anymore we excluded the audispd logs specifically from the platform-vcap filters so we don't put extra work on the parsers. There are ~115k messages/hour in a dev environment from audispd.

Also we don't set the @type to vcap and don't add the vcap tag as it doesn't make sense anymore. Nothing depends on it. The default @type will be cf instead of vcap. You can have a look at the tests changes to have a picture about what will change.

If you need to run the spec tests locally:

```
cd src/logsearch-config
docker run --rm -ti -v $(pwd):/mnt -w /mnt jruby:9.1-alpine bash
bundle install
bundle exec rake
```

## How to review

Code review

Test as part of https://github.com/alphagov/paas-cf/pull/1298

## Who can review

Not me.